### PR TITLE
fix(archiver): store and shut down API server during Stop()

### DIFF
--- a/archiver/service/service.go
+++ b/archiver/service/service.go
@@ -29,6 +29,7 @@ type ArchiverService struct {
 	stopped       atomic.Bool
 	log           log.Logger
 	metricsServer *httputil.HTTPServer
+	apiServer     *httputil.HTTPServer
 	cfg           flags.ArchiverConfig
 	metrics       metrics.Metricer
 	api           *API
@@ -54,6 +55,7 @@ func (a *ArchiverService) Start(ctx context.Context) error {
 	}
 
 	a.log.Info("Archiver API server started", "address", srv.Addr().String())
+	a.apiServer = srv
 
 	return a.archiver.Start(ctx)
 }
@@ -68,6 +70,12 @@ func (a *ArchiverService) Stop(ctx context.Context) error {
 
 	if a.metricsServer != nil {
 		if err := a.metricsServer.Stop(ctx); err != nil {
+			return err
+		}
+	}
+
+	if a.apiServer != nil {
+		if err := a.apiServer.Stop(ctx); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #55

## Problem
The HTTP API server started in `Start()` was stored only in a local variable and never assigned to the `ArchiverService` struct. As a result, `Stop()` had no reference to it and could not shut it down.

This could cause:
- Port conflicts on restart
- Leaked goroutines and sockets
- Incomplete graceful shutdown

## Fix
- Added `apiServer *httputil.HTTPServer` field to `ArchiverService`
- Assigned the server to the struct in `Start()`
- Added `apiServer.Stop(ctx)` call in `Stop()`

This is consistent with how the standalone API service in `api/service/service.go` already handles shutdown.