### PR TITLE
fix(archiver): propagate context in rearchiveRange and fix structured log

### DIFF
--- a/archiver/service/api.go
+++ b/archiver/service/api.go
@@ -97,7 +97,7 @@ func (a *API) rearchiveBlocks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blockStart, blockEnd, err := a.archiver.rearchiveRange(from, to)
+	blockStart, blockEnd, err := a.archiver.rearchiveRange(r.Context(), from, to)
 	if err != nil {
 		a.logger.Error("Failed to rearchive blocks", "err", err)
 

--- a/archiver/service/archiver.go
+++ b/archiver/service/archiver.go
@@ -241,7 +241,7 @@ func (a *Archiver) waitObtainStorageLock(ctx context.Context) {
 
 	err = a.dataStoreClient.WriteLockfile(ctx, storage.Lockfile{ArchiverId: a.id, Timestamp: currentTime})
 	if err != nil {
-		a.log.Crit("failed to write to lockfile: %v", err)
+		a.log.Crit("failed to write to lockfile", "err", err)
 	}
 	a.log.Info("obtained storage lock")
 
@@ -387,7 +387,7 @@ func (a *Archiver) processBlocksUntilKnownBlock(ctx context.Context) {
 // rearchiveRange will rearchive all blocks in the range from the given start to end. It returns the start and end of the
 // range that was successfully rearchived. On any persistent errors, it will halt archiving and return the range of blocks
 // that were rearchived and the error that halted the process.
-func (a *Archiver) rearchiveRange(from uint64, to uint64) (uint64, uint64, error) {
+func (a *Archiver) rearchiveRange(ctx context.Context, from uint64, to uint64) (uint64, uint64, error) {
 	for i := from; i <= to; i++ {
 		id := strconv.FormatUint(i, 10)
 
@@ -395,8 +395,8 @@ func (a *Archiver) rearchiveRange(from uint64, to uint64) (uint64, uint64, error
 
 		l.Info("rearchiving block")
 
-		rewritten, err := retry.Do(context.Background(), rearchiveMaximumRetries, retry.Exponential(), func() (bool, error) {
-			_, _, e := a.persistBlobsForBlockToS3(context.Background(), id, true)
+		rewritten, err := retry.Do(ctx, rearchiveMaximumRetries, retry.Exponential(), func() (bool, error) {
+			_, _, e := a.persistBlobsForBlockToS3(ctx, id, true)
 
 			// If the block is not found, we can assume that the slot has been skipped
 			if e != nil {

--- a/archiver/service/archiver_test.go
+++ b/archiver/service/archiver_test.go
@@ -459,7 +459,7 @@ func TestArchiver_RearchiveRange(t *testing.T) {
 
 	from, to := blobtest.StartSlot+1, blobtest.StartSlot+4
 
-	actualFrom, actualTo, err := svc.rearchiveRange(from, to)
+	actualFrom, actualTo, err := svc.rearchiveRange(context.Background(), from, to)
 	// Should index the whole range
 	require.NoError(t, err)
 	require.Equal(t, from, actualFrom)


### PR DESCRIPTION
Fixes #58.

## Changes

### 1. Context propagation in `rearchiveRange`

`rearchiveRange` previously used `context.Background()` for both `retry.Do` and `persistBlobsForBlockToS3`, making it impossible to cancel the operation on archiver shutdown or HTTP request timeout.

- Changed the function signature to accept `context.Context`
- Passed the context through to `retry.Do` and `persistBlobsForBlockToS3`
- Updated the HTTP handler to pass `r.Context()`, so the 60-second middleware timeout and client disconnects correctly abort the operation
- Updated the test call site to pass `context.Background()`

### 2. Structured logging fix in `waitObtainStorageLock`

`a.log.Crit("failed to write to lockfile: %v", err)` passed `%v` as a key name to the structured logger, silently dropping the error value from log output. Changed to `a.log.Crit("failed to write to lockfile", "err", err)`.

## Test plan

- [x] All existing archiver tests pass (`go test ./archiver/...`)
- [x] `go build ./...` clean
- [ ] Verify rearchive is cancelled when archiver shuts down mid-range
- [ ] Verify lockfile write failure message appears correctly in structured logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)