### PR TITLE
fix(validator): guard against uint64 underflow in Start() slot arithmetic

### DIFF
--- a/validator/service/service.go
+++ b/validator/service/service.go
@@ -73,8 +73,19 @@ func (a *ValidatorService) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to get beacon block header: %w", err)
 	}
 
-	end := header.Data.Header.Message.Slot - finalizedL1Offset
-	start := end - phase0.Slot(a.cfg.NumBlocks)
+	headSlot := header.Data.Header.Message.Slot
+	if headSlot < finalizedL1Offset {
+		return fmt.Errorf("beacon head slot %d is below finalizedL1Offset %d, cannot compute end slot", headSlot, finalizedL1Offset)
+	}
+	end := headSlot - finalizedL1Offset
+
+	numBlocks := phase0.Slot(a.cfg.NumBlocks)
+	var start phase0.Slot
+	if end < numBlocks {
+		start = 0
+	} else {
+		start = end - numBlocks
+	}
 
 	go a.checkBlobs(ctx, start, end)
 


### PR DESCRIPTION
Fixes #69.

phase0.Slot is uint64. In Start(), two subtractions can wrap around:

1. headSlot - finalizedL1Offset wraps if the beacon head is below slot 64. Added an early return with a descriptive error.
2. end - phase0.Slot(a.cfg.NumBlocks) wraps if the chain has fewer than NumBlocks slots. Clamped start to 0 in that case instead of underflowing.

The checkBlobs loop iterates slot := start to end, so a wrapped start value would cause the validator to hang iterating an astronomically large range. All existing tests pass.