### PR TITLE
fix(storage): create file storage directory before use

### DIFF
--- a/common/storage/file.go
+++ b/common/storage/file.go
@@ -17,6 +17,10 @@ type FileStorage struct {
 }
 
 func NewFileStorage(dir string, l log.Logger) *FileStorage {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		l.Crit("failed to create file storage directory", "dir", dir, "err", err)
+	}
+
 	storage := &FileStorage{
 		log:       l,
 		directory: dir,

--- a/common/storage/file_test.go
+++ b/common/storage/file_test.go
@@ -49,6 +49,21 @@ func TestExists(t *testing.T) {
 	runTestExists(t, fs)
 }
 
+func TestNewFileStorageCreatesDirectory(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	tempDir := t.TempDir()
+	storageDir := tempDir + "/nested/storage"
+
+	fs := NewFileStorage(storageDir, logger)
+
+	_, err := os.Stat(storageDir)
+	require.NoError(t, err)
+	_, err = fs.ReadBackfillProcesses(context.Background())
+	require.NoError(t, err)
+	_, err = fs.ReadLockfile(context.Background())
+	require.NoError(t, err)
+}
+
 func runTestRead(t *testing.T, s DataStore) {
 	id := common.Hash{1, 2, 3}
 


### PR DESCRIPTION
## Summary
- create the configured file-storage directory before initializing metadata files
- cover fresh nested storage directories in FileStorage tests

Fixes #71.

## Testing
- `git diff --check`

Note: Go is not installed in this Windows environment, so `go test ./common/storage/...` and `gofmt` could not be run locally.