### PR TITLE
fix: create file storage directory on initialization

### DIFF
--- a/common/storage/file.go
+++ b/common/storage/file.go
@@ -17,6 +17,10 @@ type FileStorage struct {
 }
 
 func NewFileStorage(dir string, l log.Logger) *FileStorage {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		l.Crit("failed to create file storage directory", "err", err)
+	}
+
 	storage := &FileStorage{
 		log:       l,
 		directory: dir,

--- a/common/storage/file_test.go
+++ b/common/storage/file_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -112,4 +113,14 @@ func TestReadInvalidData(t *testing.T) {
 	_, err = fs.ReadBlob(context.Background(), id)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrMarshaling))
+}
+
+func TestNewFileStorageCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "blob-data")
+
+	_ = NewFileStorage(dir, log.New())
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("expected storage directory to exist: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

- create the configured file storage directory during `NewFileStorage` initialization
- add a regression test covering a missing storage directory

## Why

The file backend initializes `backfill_processes` and `lockfile` immediately, but previously assumed the configured directory already existed. On a fresh deployment with a new `--file-directory`, those metadata writes can fail because the parent directory is missing.

Closes #71.

## Validation

- reproduced the failure locally with a regression test
- `go test ./common/storage -v`
- `git diff --cached --check`

S3 integration tests were skipped because `RUN_INTEGRATION_TESTS` was not set.